### PR TITLE
Apply small union improvement.

### DIFF
--- a/include/cbor_common.h
+++ b/include/cbor_common.h
@@ -58,6 +58,7 @@ union {
 	                             updated when an element is correctly
 	                             processed. */
 };
+	uint8_t const *payload_bak; /**< Temporary backup of payload. */
 	size_t elem_count; /**< The current element is part of a LIST or a MAP,
 	                        and this keeps count of how many elements are
 	                        expected. This will be checked before processing


### PR DESCRIPTION
Make all calls to functions in cbor_decode.c restore the previous
state if they fail. This means the union_elem_code() call can
sometimes be dropped.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>