### PR TITLE
Add support for native_posix_64.

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ The process is the same for encoding, except:
  * has been specified as an ENTRY_TYPE in the cmake call. */
 Pet_t pet = { /* Initialize with desired data. */ };
 uint8_t output[100]; /* 100 is an example. Must be large enough for data to fit. */
-size_t out_len;
+uint32_t out_len;
 bool success = cbor_encode_Pet(output, sizeof(output), &pet, &out_len);
 ```
 

--- a/include/cbor_common.h
+++ b/include/cbor_common.h
@@ -17,7 +17,7 @@
 typedef struct
 {
 	const uint8_t *value;
-	size_t len;
+	uint32_t len;
 } cbor_string_type_t;
 
 #ifdef CDDL_CBOR_VERBOSE
@@ -59,11 +59,11 @@ union {
 	                             processed. */
 };
 	uint8_t const *payload_bak; /**< Temporary backup of payload. */
-	size_t elem_count; /**< The current element is part of a LIST or a MAP,
-	                        and this keeps count of how many elements are
-	                        expected. This will be checked before processing
-	                        and decremented if the element is correctly
-	                        processed. */
+	uint32_t elem_count; /**< The current element is part of a LIST or a MAP,
+	                          and this keeps count of how many elements are
+	                          expected. This will be checked before processing
+	                          and decremented if the element is correctly
+	                          processed. */
 	uint8_t const *payload_end; /**< The end of the payload. This will be
 	                                 checked against payload before
 	                                 processing each element. */
@@ -72,8 +72,8 @@ union {
 
 struct cbor_state_backups_s{
 	cbor_state_t *backup_list;
-	size_t current_backup;
-	size_t num_backups;
+	uint32_t current_backup;
+	uint32_t num_backups;
 };
 
 /** Function pointer type used with multi_decode.
@@ -122,10 +122,10 @@ do {\
 #define FLAG_DISCARD 2UL
 #define FLAG_TRANSFER_PAYLOAD 4UL
 
-bool new_backup(cbor_state_t *state, size_t new_elem_count);
+bool new_backup(cbor_state_t *state, uint32_t new_elem_count);
 
 bool restore_backup(cbor_state_t *state, uint32_t flags,
-		size_t max_elem_count);
+		uint32_t max_elem_count);
 
 bool union_start_code(cbor_state_t *state);
 
@@ -133,8 +133,8 @@ bool union_elem_code(cbor_state_t *state);
 
 bool union_end_code(cbor_state_t *state);
 
-bool entry_function(const uint8_t *payload, size_t payload_len,
-		const void *struct_ptr, size_t *payload_len_out,
-		cbor_encoder_t func, size_t elem_count, size_t num_backups);
+bool entry_function(const uint8_t *payload, uint32_t payload_len,
+		const void *struct_ptr, uint32_t *payload_len_out,
+		cbor_encoder_t func, uint32_t elem_count, uint32_t num_backups);
 
 #endif /* CBOR_COMMON_H__ */

--- a/include/cbor_debug.h
+++ b/include/cbor_debug.h
@@ -13,7 +13,7 @@
 #define min(a,b) (((a) < (b)) ? (a) : (b))
 
 __attribute__((used))
-static void print_compare_lines(const uint8_t *str1, const uint8_t *str2, size_t size)
+static void print_compare_lines(const uint8_t *str1, const uint8_t *str2, uint32_t size)
 {
 	for (uint32_t j = 0; j < size; j++) {
 		printk ("%x ", str1[j]);
@@ -31,7 +31,7 @@ static void print_compare_lines(const uint8_t *str1, const uint8_t *str2, size_t
 }
 
 __attribute__((used))
-static void print_compare_strings(const uint8_t *str1, const uint8_t *str2, size_t size)
+static void print_compare_strings(const uint8_t *str1, const uint8_t *str2, uint32_t size)
 {
 	for (uint32_t i = 0; i <= size / 16; i++) {
 		printk("line %d (char %d)\r\n", i, i*16);
@@ -42,7 +42,7 @@ static void print_compare_strings(const uint8_t *str1, const uint8_t *str2, size
 }
 
 __attribute__((used))
-static void print_compare_strings_diff(const uint8_t *str1, const uint8_t *str2, size_t size)
+static void print_compare_strings_diff(const uint8_t *str1, const uint8_t *str2, uint32_t size)
 {
 	bool printed = false;
 	for (uint32_t i = 0; i <= size / 16; i++) {

--- a/include/cbor_decode.h
+++ b/include/cbor_decode.h
@@ -17,9 +17,9 @@
  * $CDDL_GEN_BASE/scripts/cddl_gen.py
  *
  * Some details to notice about this library:
- *  - Integers are all 32 bits (uint32_t and size_t). This means that CBOR's
- *    64 bit values are not supported. This applies to integer types, as well as
- *    lengths for other types.
+ *  - Integers are all 32 bits (uint32_t). This means that CBOR's 64 bit values
+ *    are not supported, even when the code is running on a 64 bit architecture.
+ *    This applies to integer types, as well as lengths for other types.
  *  - Strings are kept in the container type cbor_string_type_t, which is a
  *    pointer and a length.
  *  - When a function returns false, it only means that decoding that particular
@@ -179,7 +179,7 @@ bool tag_expect(cbor_state_t *state, uint32_t result);
  *          @code{c}
  *              uint32_t int_min = 0;
  *              uint32_t int_max = 100;
- *              size_t bstr_size = 8;
+ *              uint32_t bstr_size = 8;
  *              uint32_t ints[3];
  *              cbor_string_type_t bstrs[2];
  *              bool res;
@@ -216,11 +216,11 @@ bool tag_expect(cbor_state_t *state, uint32_t result);
  * @retval false  If @p decoder failed before having decoded @p min_decode
  *                values.
  */
-bool multi_decode(size_t min_decode, size_t max_decode, size_t *num_decode,
+bool multi_decode(uint32_t min_decode, uint32_t max_decode, uint32_t *num_decode,
 		cbor_decoder_t decoder, cbor_state_t *state, void *result,
-		size_t result_len);
+		uint32_t result_len);
 
-bool present_decode(size_t *present,
+bool present_decode(uint32_t *present,
 		cbor_decoder_t decoder,
 		cbor_state_t *state,
 		void *result);

--- a/include/cbor_encode.h
+++ b/include/cbor_encode.h
@@ -60,16 +60,16 @@ bool tstrx_encode(cbor_state_t *state, const cbor_string_type_t *result);
  * The contents of the list can be decoded via subsequent function calls.
  * A state backup is created to keep track of the element count.
  */
-bool list_start_encode(cbor_state_t *state, size_t max_num);
+bool list_start_encode(cbor_state_t *state, uint32_t max_num);
 
 /** Encode a MAP header. */
-bool map_start_encode(cbor_state_t *state, size_t max_num);
+bool map_start_encode(cbor_state_t *state, uint32_t max_num);
 
 /** Encode end of a LIST. Do some checks and deallocate backup. */
-bool list_end_encode(cbor_state_t *state, size_t max_num);
+bool list_end_encode(cbor_state_t *state, uint32_t max_num);
 
 /** Encode end of a MAP. Do some checks and deallocate backup. */
-bool map_end_encode(cbor_state_t *state, size_t max_num);
+bool map_end_encode(cbor_state_t *state, uint32_t max_num);
 
 /** Encode a "nil" primitive value. result should be NULL. */
 bool nilx_put(cbor_state_t *state, const void *result);
@@ -97,7 +97,7 @@ bool tag_encode(cbor_state_t *state, uint32_t tag);
  *          @code{c}
  *              uint32_t int_min = 0;
  *              uint32_t int_max = 100;
- *              size_t bstr_size = 8;
+ *              uint32_t bstr_size = 8;
  *              uint32_t ints[3];
  *              cbor_string_type_t bstrs[2] = <initialize here>;
  *              bool res;
@@ -133,11 +133,11 @@ bool tag_encode(cbor_state_t *state, uint32_t tag);
  * @retval false  If @p encoder failed before having encoded @p min_encode
  *                values.
  */
-bool multi_encode(size_t min_encode, size_t max_encode, const size_t *num_encode,
+bool multi_encode(uint32_t min_encode, uint32_t max_encode, const uint32_t *num_encode,
 		cbor_encoder_t encoder, cbor_state_t *state, const void *input,
-		size_t result_len);
+		uint32_t result_len);
 
-bool present_encode(const size_t *present,
+bool present_encode(const uint32_t *present,
 		cbor_encoder_t encoder,
 		cbor_state_t *state,
 		const void *input);

--- a/scripts/cddl_gen.py
+++ b/scripts/cddl_gen.py
@@ -1431,11 +1431,11 @@ class CodeGenerator(CddlXcoder):
 
     # Declaration of the "present" variable for this element.
     def present_var(self):
-        return ["size_t %s;" % self.present_var_name()]
+        return ["uint32_t %s;" % self.present_var_name()]
 
     # Declaration of the "count" variable for this element.
     def count_var(self):
-        return ["size_t %s;" % self.count_var_name()]
+        return ["uint32_t %s;" % self.count_var_name()]
 
     # Declaration of the "choice" variable for this element.
     def choice_var(self):
@@ -1991,9 +1991,9 @@ class CodeGenerator(CddlXcoder):
     def public_xcode_func_sig(self):
         return f"""
 bool cbor_{self.xcode_func_name()}(
-		{"const " if self.mode == "decode" else ""}uint8_t *payload, size_t payload_len,
+		{"const " if self.mode == "decode" else ""}uint8_t *payload, uint32_t payload_len,
 		{"" if self.mode == "decode" else "const "}{self.type_name()} *{struct_ptr_name(self.mode)},
-		{"size_t *payload_len_out"})"""
+		{"uint32_t *payload_len_out"})"""
 
     def type_test_xcode_func_sig(self):
         return f"""
@@ -2096,11 +2096,11 @@ static bool {xcoder.func_name}(
             xcoder.type_name if struct_ptr_name(self.mode) in body else "void"} *{struct_ptr_name(self.mode)})
 {{
 	cbor_print("%s\\n", __func__);
-	{f"size_t temp_elem_counts[{body.count('temp_elem_count')}];" if "temp_elem_count" in body else ""}
-	{"size_t *temp_elem_count = temp_elem_counts;" if "temp_elem_count" in body else ""}
+	{f"uint32_t temp_elem_counts[{body.count('temp_elem_count')}];" if "temp_elem_count" in body else ""}
+	{"uint32_t *temp_elem_count = temp_elem_counts;" if "temp_elem_count" in body else ""}
 	{"uint32_t current_list_num;" if "current_list_num" in body else ""}
 	{"uint8_t const *payload_bak;" if "payload_bak" in body else ""}
-	{"size_t elem_count_bak;" if "elem_count_bak" in body else ""}
+	{"uint32_t elem_count_bak;" if "elem_count_bak" in body else ""}
 	{"uint32_t tmp_value;" if "tmp_value" in body else ""}
 	{"cbor_string_type_t tmp_str;" if "tmp_str" in body else ""}
 	{"bool int_res;" if "int_res" in body else ""}

--- a/src/cbor_common.c
+++ b/src/cbor_common.c
@@ -10,14 +10,17 @@
 #include <string.h>
 #include "cbor_common.h"
 
-bool new_backup(cbor_state_t *state, size_t new_elem_count)
+_Static_assert((sizeof(size_t) == sizeof(void *)),
+	"This code needs size_t to be the same length as pointers.");
+
+bool new_backup(cbor_state_t *state, uint32_t new_elem_count)
 {
 	if ((state->backups->current_backup + 1)
 		>= state->backups->num_backups) {
 		FAIL();
 	}
 
-	size_t i = ++(state->backups->current_backup);
+	uint32_t i = ++(state->backups->current_backup);
 	memcpy(&state->backups->backup_list[i], state,
 		sizeof(cbor_state_t));
 
@@ -28,17 +31,17 @@ bool new_backup(cbor_state_t *state, size_t new_elem_count)
 
 
 bool restore_backup(cbor_state_t *state, uint32_t flags,
-		size_t max_elem_count)
+		uint32_t max_elem_count)
 {
 	const uint8_t *payload = state->payload;
-	const size_t elem_count = state->elem_count;
+	const uint32_t elem_count = state->elem_count;
 
 	if (state->backups->current_backup == 0) {
 		FAIL();
 	}
 
 	if (flags & FLAG_RESTORE) {
-		size_t i = state->backups->current_backup;
+		uint32_t i = state->backups->current_backup;
 
 		memcpy(state, &state->backups->backup_list[i],
 			sizeof(cbor_state_t));
@@ -87,9 +90,9 @@ bool union_end_code(cbor_state_t *state)
 	return true;
 }
 
-bool entry_function(const uint8_t *payload, size_t payload_len,
-		const void *struct_ptr, size_t *payload_len_out,
-		cbor_encoder_t func, size_t elem_count, size_t num_backups)
+bool entry_function(const uint8_t *payload, uint32_t payload_len,
+		const void *struct_ptr, uint32_t *payload_len_out,
+		cbor_encoder_t func, uint32_t elem_count, uint32_t num_backups)
 {
 	cbor_state_t state = {
 		.payload = payload,

--- a/src/cbor_decode.c
+++ b/src/cbor_decode.c
@@ -74,7 +74,7 @@ do {\
  *          big to little-endian if necessary (@ref CONFIG_BIG_ENDIAN).
  */
 static bool value_extract(cbor_state_t *state,
-		void *const result, size_t result_len)
+		void *const result, uint32_t result_len)
 {
 	cbor_trace();
 	cbor_assert(result_len != 0, "0-length result not supported.\n");
@@ -234,8 +234,6 @@ static bool strx_start_decode(cbor_state_t *state,
 		FAIL();
 	}
 
-	_Static_assert((sizeof(size_t) == sizeof(uint32_t)),
-			"This code needs size_t to be 4 bytes long.");
 	if (!uint32_decode(state, &result->len)) {
 		FAIL();
 	}
@@ -335,7 +333,7 @@ bool tstrx_expect(cbor_state_t *state, cbor_string_type_t *result)
 static bool list_map_start_decode(cbor_state_t *state,
 		cbor_major_type_t exp_major_type)
 {
-	size_t new_elem_count;
+	uint32_t new_elem_count;
 	uint8_t major_type = MAJOR_TYPE(*state->payload);
 
 	if (major_type != exp_major_type) {
@@ -500,9 +498,9 @@ bool any_decode(cbor_state_t *state, void *result)
 
 	uint8_t major_type = MAJOR_TYPE(*state->payload);
 	uint32_t value;
-	size_t num_decode;
+	uint32_t num_decode;
 	void *null_result = NULL;
-	size_t temp_elem_count;
+	uint32_t temp_elem_count;
 	uint8_t const *payload_bak;
 
 	if (!value_extract(state, &value, sizeof(value))) {
@@ -570,17 +568,17 @@ bool tag_expect(cbor_state_t *state, uint32_t result)
 }
 
 
-bool multi_decode(size_t min_decode,
-		size_t max_decode,
-		size_t *num_decode,
+bool multi_decode(uint32_t min_decode,
+		uint32_t max_decode,
+		uint32_t *num_decode,
 		cbor_decoder_t decoder,
 		cbor_state_t *state,
 		void *result,
-		size_t result_len)
+		uint32_t result_len)
 {
-	for (size_t i = 0; i < max_decode; i++) {
+	for (uint32_t i = 0; i < max_decode; i++) {
 		uint8_t const *payload_bak = state->payload;
-		size_t elem_count_bak = state->elem_count;
+		uint32_t elem_count_bak = state->elem_count;
 
 		if (!decoder(state,
 				(uint8_t *)result + i*result_len)) {
@@ -601,12 +599,12 @@ bool multi_decode(size_t min_decode,
 }
 
 
-bool present_decode(size_t *present,
+bool present_decode(uint32_t *present,
 		cbor_decoder_t decoder,
 		cbor_state_t *state,
 		void *result)
 {
-	size_t num_decode;
+	uint32_t num_decode;
 	bool retval = multi_decode(0, 1, &num_decode, decoder, state, result, 0);
 	if (retval) {
 		*present = num_decode;

--- a/tests/cbor_decode/test.sh
+++ b/tests/cbor_decode/test.sh
@@ -5,14 +5,17 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-for dir in 'test1_suit_old_formats/' 'test2_suit/' 'test3_simple/' 'test5_strange/' 'test7_suit9_simple' ;
-do
-        pushd "$dir"
+
+do_test() {
+        test_dir=$1
+        test_platform=$2
+
+        pushd "$test_dir"
 
         if [ -d "build" ]; then rm -r build; fi
         mkdir build &&cd build
 
-        cmake -GNinja -DBOARD=native_posix .. 2>&1 1> test.log
+        cmake -GNinja -DBOARD=$test_platform .. 2>&1 1> test.log
         if [[ $? -ne 0 ]]; then
             cat test.log
             exit 1
@@ -28,4 +31,15 @@ do
         [[ $? -ne 0 ]] && exit 1
 
         popd
+}
+
+
+for dir in 'test1_suit_old_formats/' 'test2_suit/' 'test3_simple/' 'test5_strange/' 'test7_suit9_simple' ;
+do
+        for board in 'native_posix' 'native_posix_64' ;
+        do
+                echo ""
+                echo "do_test $dir $board"
+                do_test $dir $board
+        done
 done

--- a/tests/cbor_decode/test1_suit_old_formats/src/main.c
+++ b/tests/cbor_decode/test1_suit_old_formats/src/main.c
@@ -102,7 +102,7 @@ static struct SUIT_Outer_Wrapper outerwrapper4 = {0};
 // Example 9.1 from draft-moran-suit-manifest-03
 void test_1(void)
 {
-	size_t decode_len;
+	uint32_t decode_len;
 	uint8_t expected_tag[] = {
 		0x8c, 0xaf, 0x92, 0x83, 0xb1, 0x36, 0x66, 0xca,
 		0x4e, 0x50, 0xf7, 0xa1, 0xee, 0xe8, 0x6b, 0xa4,
@@ -150,7 +150,7 @@ void test_1(void)
 // Example 9.3 from draft-moran-suit-manifest-03
 void test_2(void)
 {
-	size_t decode_len;
+	uint32_t decode_len;
 	memset(&outerwrapper, 0, sizeof(struct OuterWrapper));
 	char expected_updateDescription[] =
 		"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc "
@@ -200,7 +200,7 @@ void test_2(void)
 // Example 1 from draft-moran-suit-manifest-04
 void test_3(void)
 {
-	size_t decode_len;
+	uint32_t decode_len;
 	char expected_uri[] = "http://example.com/file.bin";
 	memset(&outerwrapper4, 0, sizeof(struct SUIT_Outer_Wrapper));
 	zassert_true(cbor_decode_SUIT_Outer_Wrapper(test_vector4,

--- a/tests/cbor_decode/test2_suit/src/main.c
+++ b/tests/cbor_decode/test2_suit/src/main.c
@@ -39,7 +39,7 @@ static struct SUIT_Command_Sequence sequence;
 void test_5(void)
 {
 	struct SUIT_Manifest *manifest;
-	size_t decode_len;
+	uint32_t decode_len;
 	struct SUIT_Component_Identifier *component;
 	uint8_t expected_component0[] = {0x46, 0x6c, 0x61, 0x73, 0x68};
 	uint8_t expected_component1[] = {0x00, 0x34, 0x01};

--- a/tests/cbor_decode/test3_simple/src/main.c
+++ b/tests/cbor_decode/test3_simple/src/main.c
@@ -124,7 +124,7 @@ uint8_t serial_rec_input2[] = {
 void test_pet(void)
 {
 	struct Pet pet;
-	size_t decode_len;
+	uint32_t decode_len;
 	uint8_t input[] = {
 		0x83, 0x82, 0x63, 0x66, 0x6f, 0x6f, 0x63, 0x62, 0x61, 0x72,
 		0x48, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
@@ -145,7 +145,7 @@ void test_pet(void)
 void test_serial1(void)
 {
 	struct Upload upload;
-	size_t decode_len;
+	uint32_t decode_len;
 	bool ret = cbor_decode_Upload(serial_rec_input1,
 			sizeof(serial_rec_input1), &upload, &decode_len);
 	zassert_true(ret, "decoding failed.");
@@ -168,7 +168,7 @@ void test_serial1(void)
 void test_serial2(void)
 {
 	struct Upload upload;
-	size_t decode_len;
+	uint32_t decode_len;
 	bool ret = cbor_decode_Upload(serial_rec_input2,
 			sizeof(serial_rec_input2), &upload, &decode_len);
 	zassert_true(ret, "decoding failed.");

--- a/tests/cbor_decode/test5_strange/src/main.c
+++ b/tests/cbor_decode/test5_strange/src/main.c
@@ -10,7 +10,7 @@
 
 void test_numbers(void)
 {
-	size_t decode_len = 0xFFFFFFFF;
+	uint32_t decode_len = 0xFFFFFFFF;
 	const uint8_t payload_numbers1[] = {
 		0x8A, // List start
 			0x01, // 1
@@ -287,7 +287,7 @@ void test_union(void)
 	const uint8_t payload_union10_inv[] = {
 		0x03, 0x23, 0x03, 0x23, 0x03, 0x23, 0x03, 0x23,
 		0x03, 0x23, 0x03, 0x23, 0x03, 0x23}; /* Too many */
-	size_t decode_len;
+	uint32_t decode_len;
 
 	struct Union_ _union;
 	zassert_true(cbor_decode_Union(payload_union1, sizeof(payload_union1),
@@ -729,7 +729,7 @@ void test_value_range(void)
 	};
 
 	struct ValueRange output;
-	size_t out_len;
+	uint32_t out_len;
 
 	zassert_true(cbor_decode_ValueRange(payload_value_range1, sizeof(payload_value_range1),
 					&output, &out_len), NULL);

--- a/tests/cbor_encode/test.sh
+++ b/tests/cbor_encode/test.sh
@@ -5,13 +5,18 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+
 do_test() {
-        pushd "$1"
+        test_dir=$1
+        test_platform=$2
+        canonical_val=$3
+
+        pushd "$test_dir"
 
         if [ -d "build" ]; then rm -r build; fi
         mkdir build && cd build
 
-        cmake -GNinja -DBOARD=native_posix $2 .. 2>&1 1> test.log
+        cmake -GNinja -DBOARD=$test_platform $canonical_val .. 2>&1 1> test.log
         if [[ $? -ne 0 ]]; then
             cat test.log
             exit 1
@@ -29,12 +34,18 @@ do_test() {
         popd
 }
 
+
 for dir in 'test1_suit/' 'test2_simple/' 'test3_strange/' ;
 do
-        do_test $dir -DCANONICAL=CANONICAL
-done
-
-for dir in 'test2_simple/' 'test3_strange/' ;
-do
-        do_test $dir
+        for board in 'native_posix' 'native_posix_64' ;
+        do
+                for canonical in '-DCANONICAL=CANONICAL' '' ;
+                do
+                        if [[ $canonical == '-DCANONICAL=CANONICAL' ]] || [[ $dir != 'test1_suit/' ]] ; then
+                                echo ""
+                                echo "do_test $dir $board $canonical"
+                                do_test $dir $board $canonical
+                        fi
+                done
+        done
 done

--- a/tests/cbor_encode/test1_suit/src/main.c
+++ b/tests/cbor_encode/test1_suit/src/main.c
@@ -238,7 +238,7 @@ void test_command_sequence(cbor_string_type_t *sequence_str,
 	bool try_each1_present;
 	cbor_string_type_t *try_each2;
 	bool try_each2_present;
-	size_t out_len;
+	uint32_t out_len;
 
 	if (!present) {
 		return;
@@ -310,7 +310,7 @@ void test_command_sequence(cbor_string_type_t *sequence_str,
 	}
 }
 
-void test_manifest(const uint8_t *input, size_t len)
+void test_manifest(const uint8_t *input, uint32_t len)
 {
 	struct SUIT_Outer_Wrapper outerwrapper1 = {0};
 	struct SUIT_Manifest *manifest;
@@ -336,7 +336,7 @@ void test_manifest(const uint8_t *input, size_t len)
 	cbor_string_type_t *run;
 	bool run_present;
 	bool res;
-	size_t out_len;
+	uint32_t out_len;
 
 	cbor_print("test_vector at: 0x%x\r\n", (uint32_t)input);
 	cbor_print("test_vector end at: 0x%x\r\n",

--- a/tests/cbor_encode/test2_simple/src/main.c
+++ b/tests/cbor_encode/test2_simple/src/main.c
@@ -147,7 +147,7 @@ void test_pet(void)
 	};
 
 	uint8_t output[25];
-	size_t out_len;
+	uint32_t out_len;
 
 	zassert_true(cbor_encode_Pet(output, sizeof(output), &pet, &out_len), "");
 

--- a/tests/cbor_encode/test3_strange/src/main.c
+++ b/tests/cbor_encode/test3_strange/src/main.c
@@ -40,7 +40,7 @@ void test_numbers(void)
 
 	struct Numbers numbers = {0};
 	uint8_t output[100];
-	size_t out_len;
+	uint32_t out_len;
 
 	numbers._Numbers_fourtoten = 3; // Invalid
 	numbers._Numbers_twobytes = 256;
@@ -215,7 +215,7 @@ void test_strings(void)
 	uint8_t output2[100];
 	uint8_t output3[400];
 	uint8_t output4[800];
-	size_t out_len;
+	uint32_t out_len;
 
 	numbers1._Numbers_fourtoten = 5;
 	numbers1._Numbers_twobytes = 0xFFFF;
@@ -300,7 +300,7 @@ void test_optional(void)
 				._Optional_opttwo_present = true, ._Optional_manduint = 2,
 				._Optional_multi8_count = 3};
 	uint8_t output[10];
-	size_t out_len;
+	uint32_t out_len;
 
 	zassert_true(cbor_encode_Optional(output,
 			sizeof(output), &optional1, &out_len), NULL);
@@ -359,7 +359,7 @@ void test_union(void)
 	struct Union_ _union6_inv = {._Union_choice = _Union__MultiGroup, ._Union__MultiGroup._MultiGroup_count = 7};
 
 	uint8_t output[15];
-	size_t out_len;
+	uint32_t out_len;
 
 	zassert_true(cbor_encode_Union(output, sizeof(output),
 				&_union1, &out_len), NULL);
@@ -409,7 +409,7 @@ void test_levels(void)
 		END END END
 	};
 	uint8_t output[32];
-	size_t out_len;
+	uint32_t out_len;
 
 	struct Level2 level1 = {._Level2__Level3_count = 2, ._Level2__Level3 = {
 		{._Level3__Level4_count = 4}, {._Level3__Level4_count = 4}
@@ -482,7 +482,7 @@ void test_map(void)
 	};
 
 	uint8_t output[25];
-	size_t out_len;
+	uint32_t out_len;
 
 	zassert_true(cbor_encode_Map(output, sizeof(output),
 			&map1, &out_len), NULL);
@@ -538,7 +538,7 @@ void test_nested_list_map(void)
 		}
 	};
 	uint8_t output[40];
-	size_t out_len;
+	uint32_t out_len;
 
 	zassert_true(cbor_encode_NestedListMap(output,
 			sizeof(output), &listmap1, &out_len), NULL);
@@ -610,7 +610,7 @@ void test_nested_map_list_map(void)
 		}
 	};
 	uint8_t output[30];
-	size_t out_len;
+	uint32_t out_len;
 
 	zassert_true(cbor_encode_NestedMapListMap(output,
 			sizeof(output), &maplistmap1, &out_len), NULL);
@@ -701,7 +701,7 @@ void test_range(void)
 	};
 
 	uint8_t output[25];
-	size_t out_len;
+	uint32_t out_len;
 
 	zassert_true(cbor_encode_Range(output, sizeof(output), &input1,
 				&out_len), NULL);
@@ -803,7 +803,7 @@ void test_value_range(void)
 	};
 
 	uint8_t output[25];
-	size_t out_len;
+	uint32_t out_len;
 
 	zassert_true(cbor_encode_ValueRange(output, sizeof(output), &input1,
 				&out_len), NULL);


### PR DESCRIPTION
Use uint32_t instead of size_t, except when doing pointer arithmetic.
Run tests on both native_posix and native_posix_64.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>