### PR TITLE
cddl_gen.py: Add support for entry types with no list

### DIFF
--- a/scripts/cddl_gen.py
+++ b/scripts/cddl_gen.py
@@ -797,6 +797,8 @@ class CddlXcoder(CddlParser):
                      self.value))
             list(map(lambda child: child.set_skipped(self.skip_condition()),
                      self.value))
+        elif self in self.my_types.values() and self.type != "OTHER":
+            self.set_skipped(not self.multi_member())
         if self.key is not None:
             self.key.set_access_prefix(self.var_access())
         if self.cbor_var_condition():

--- a/tests/cbor_decode/test5_strange/CMakeLists.txt
+++ b/tests/cbor_decode/test5_strange/CMakeLists.txt
@@ -25,6 +25,9 @@ target_cddl_source(app strange.cddl DECODE ENTRY_TYPES
   Level1
   Range
   ValueRange
+  SingleBstr
+  SingleInt
+  SingleInt2
   DEFAULT_MAX_QTY 6
   ${VERBOSE}
   ${CANONICAL}

--- a/tests/cbor_decode/test5_strange/src/main.c
+++ b/tests/cbor_decode/test5_strange/src/main.c
@@ -775,6 +775,34 @@ void test_value_range(void)
 				sizeof(payload_value_range11_inv), &output, &out_len), NULL);
 }
 
+void test_single(void)
+{
+	uint8_t payload_single0[] = {0x45, 'h', 'e', 'l', 'l', 'o'};
+	uint8_t payload_single1[] = {0x18, 52};
+	uint8_t payload_single2_inv[] = {0x18, 53};
+	uint8_t payload_single3[] = {9};
+	uint8_t payload_single4_inv[] = {10};
+	cbor_string_type_t result_bstr;
+	uint32_t result_int;
+	uint32_t out_len;
+
+	zassert_true(cbor_decode_SingleBstr(payload_single0, sizeof(payload_single0), &result_bstr, &out_len), NULL);
+	zassert_equal(sizeof(payload_single0), out_len, NULL);
+	zassert_equal(5, result_bstr.len, NULL);
+	zassert_mem_equal(result_bstr.value, "hello", result_bstr.len, NULL);
+	zassert_false(cbor_decode_SingleBstr(payload_single0, 5, &result_bstr, &out_len), NULL);
+
+	zassert_true(cbor_decode_SingleInt(payload_single1, sizeof(payload_single1), NULL, &out_len), NULL); // Result pointer not needed.
+	zassert_equal(sizeof(payload_single1), out_len, NULL);
+	zassert_false(cbor_decode_SingleInt(payload_single1, 1, NULL, &out_len), NULL);
+	zassert_false(cbor_decode_SingleInt(payload_single2_inv, sizeof(payload_single2_inv), NULL, &out_len), NULL);
+
+	zassert_true(cbor_decode_SingleInt2(payload_single3, sizeof(payload_single3), &result_int, &out_len), NULL);
+	zassert_equal(sizeof(payload_single3), out_len, NULL);
+	zassert_equal(9, result_int, NULL);
+	zassert_false(cbor_decode_SingleInt2(payload_single4_inv, sizeof(payload_single4_inv), &result_int, &out_len), NULL);
+}
+
 void test_main(void)
 {
 	ztest_test_suite(cbor_decode_test5,
@@ -787,7 +815,8 @@ void test_main(void)
 			 ztest_unit_test(test_nested_list_map),
 			 ztest_unit_test(test_nested_map_list_map),
 			 ztest_unit_test(test_range),
-			 ztest_unit_test(test_value_range)
+			 ztest_unit_test(test_value_range),
+			 ztest_unit_test(test_single)
 	);
 	ztest_run_test_suite(cbor_decode_test5);
 }

--- a/tests/cbor_decode/test5_strange/strange.cddl
+++ b/tests/cbor_decode/test5_strange/strange.cddl
@@ -70,3 +70,9 @@ ValueRange = [
 	equal42: uint .eq 42,
 	equalstrworld: tstr .eq "world",
 ]
+
+SingleBstr = bstr
+
+SingleInt = 52
+
+SingleInt2 = uint .lt 10

--- a/tests/cbor_encode/test3_strange/CMakeLists.txt
+++ b/tests/cbor_encode/test3_strange/CMakeLists.txt
@@ -25,6 +25,9 @@ target_cddl_source(app strange.cddl ENCODE ENTRY_TYPES
   Level1
   Range
   ValueRange
+  SingleBstr
+  SingleInt
+  SingleInt2
   DEFAULT_MAX_QTY 6
   ${VERBOSE}
   ${CANONICAL}

--- a/tests/cbor_encode/test3_strange/src/main.c
+++ b/tests/cbor_encode/test3_strange/src/main.c
@@ -833,6 +833,41 @@ void test_value_range(void)
 				&out_len), NULL);
 }
 
+void test_single(void)
+{
+	uint8_t exp_payload_single0[] = {0x45, 'h', 'e', 'l', 'l', 'o'};
+	uint8_t exp_payload_single1[] = {0x18, 52,};
+	uint8_t exp_payload_single2[] = {9};
+	uint8_t output[10];
+	uint32_t out_len;
+	cbor_string_type_t input_single0 = {
+		.value = "hello",
+		.len = 5
+	};
+	uint32_t input_single1 = 52;
+	uint32_t input_single2_ign = 53;
+	uint32_t input_single3 = 9;
+	uint32_t input_single4_inv = 10;
+
+	zassert_true(cbor_encode_SingleBstr(output, sizeof(output), &input_single0, &out_len), NULL);
+	zassert_equal(sizeof(exp_payload_single0), out_len, NULL);
+	zassert_mem_equal(exp_payload_single0, output, sizeof(exp_payload_single0), NULL);
+	zassert_false(cbor_encode_SingleBstr(output, 5, &input_single0, &out_len), NULL);
+
+	zassert_true(cbor_encode_SingleInt(output, sizeof(output), &input_single1, &out_len), NULL);
+	zassert_equal(sizeof(exp_payload_single1), out_len, NULL);
+	zassert_mem_equal(exp_payload_single1, output, sizeof(exp_payload_single1), NULL);
+	zassert_false(cbor_encode_SingleInt(output, 1, &input_single1, &out_len), NULL);
+	zassert_true(cbor_encode_SingleInt(output, sizeof(output), &input_single2_ign, &out_len), NULL);
+	zassert_equal(sizeof(exp_payload_single1), out_len, NULL);
+	zassert_mem_equal(exp_payload_single1, output, sizeof(exp_payload_single1), NULL);
+
+	zassert_true(cbor_encode_SingleInt2(output, sizeof(output), &input_single3, &out_len), NULL);
+	zassert_equal(sizeof(exp_payload_single2), out_len, NULL);
+	zassert_mem_equal(exp_payload_single2, output, sizeof(exp_payload_single2), NULL);
+	zassert_false(cbor_encode_SingleInt2(output, sizeof(output), &input_single4_inv, &out_len), NULL);
+}
+
 void test_main(void)
 {
 	ztest_test_suite(cbor_encode_test3,
@@ -845,7 +880,8 @@ void test_main(void)
 			 ztest_unit_test(test_nested_list_map),
 			 ztest_unit_test(test_nested_map_list_map),
 			 ztest_unit_test(test_range),
-			 ztest_unit_test(test_value_range)
+			 ztest_unit_test(test_value_range),
+			 ztest_unit_test(test_single)
 	);
 	ztest_run_test_suite(cbor_encode_test3);
 }

--- a/tests/cbor_encode/test3_strange/strange.cddl
+++ b/tests/cbor_encode/test3_strange/strange.cddl
@@ -70,3 +70,9 @@ ValueRange = [
 	equal42: uint .eq 42,
 	equalstrworld: tstr .eq "world",
 ]
+
+SingleBstr = bstr
+
+SingleInt = 52
+
+SingleInt2 = uint .lt 10


### PR DESCRIPTION
Simple types without a list would be generated wrongly.
This fixes https://github.com/NordicSemiconductor/cddl-gen/issues/59

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>