### PR TITLE
include/cbor_encoder: fix string encoding macros

### DIFF
--- a/include/cbor_encode.h
+++ b/include/cbor_encode.h
@@ -50,10 +50,10 @@ bool bstrx_encode(cbor_state_t *state, const cbor_string_type_t *result);
 bool tstrx_encode(cbor_state_t *state, const cbor_string_type_t *result);
 
 #define tstrx_put(state, string) \
-	tstrx_encode(state, &(cbor_string_type_t){.value = string, len = (sizeof(string) - 1)})
+	tstrx_encode(state, &(cbor_string_type_t){.value = string, .len = (sizeof(string) - 1)})
 
 #define tstrx_put_term(state, string) \
-	tstrx_encode(state, &(cbor_string_type_t){.value = string, len = strlen(string)})
+	tstrx_encode(state, &(cbor_string_type_t){.value = string, .len = strlen(string)})
 
 /** Encode a LIST header.
  *


### PR DESCRIPTION
Fixed tstrx_put() and tstrx_put_term macros. 'len' Member of
the cbor_string_type_t structure used was not extracted using a dot.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>