### PR TITLE
cbor_encode: Fix encoding data length

### DIFF
--- a/src/cbor_encode.c
+++ b/src/cbor_encode.c
@@ -79,12 +79,35 @@ static bool value_encode_len(cbor_state_t *state, cbor_major_type_t major_type,
 static size_t get_result_len(const void *const input, size_t max_result_len)
 {
 	uint8_t *u8_result  = (uint8_t *)input;
+	size_t i;
 
-	for (; max_result_len > 0; max_result_len--) {
-		if (u8_result[max_result_len - 1] != 0) {
+	for (i = 0; i < max_result_len; i++) {
+#ifdef CONFIG_BIG_ENDIAN
+		size_t idx = i;
+#else
+		size_t idx = max_result_len - 1 - i;
+#endif
+		if (u8_result[idx] != 0) {
 			break;
 		}
 	}
+	max_result_len -= i;
+
+	/* According to specification result length can be encoded on 1, 2, 4
+	 * or 8 bytes.
+	 */
+	cbor_assert(max_result_len <= 8, "Up to 8 bytes can be used to encode length.\n");
+	size_t encode_byte_cnt = 1;
+
+	for (size_t i = 0; i <= 3; i++) {
+		if (max_result_len <= encode_byte_cnt) {
+			max_result_len = encode_byte_cnt;
+			break;
+		}
+
+		encode_byte_cnt *= 2;
+	}
+
 	if ((max_result_len == 1) && (u8_result[0] <= VALUE_IN_HEADER)) {
 		max_result_len = 0;
 	}


### PR DESCRIPTION
Change fixes encoding data length and adds support for big endian byte ordering. According to specification, data length can be encoded either on 1, 2, 4 or 8 bytes.