### PR TITLE
cddl_gen.py: DataTranslator: Fix flattening of lists

### DIFF
--- a/cddl_gen/cddl_gen.py
+++ b/cddl_gen/cddl_gen.py
@@ -1104,7 +1104,11 @@ class DataTranslator(CddlXcoder):
 
     # Return the contents of a list if it has a single member and it's name is the same as us.
     def _flatten_list(self, name, obj):
-        if isinstance(obj, list) and len(obj) == 1 and len(obj[0]) == 1 and hasattr(obj[0], name):
+        if (isinstance(obj, list)
+                and len(obj) == 1
+                and (isinstance(obj[0], list) or isinstance(obj[0], tuple))
+                and len(obj[0]) == 1
+                and hasattr(obj[0], name)):
             return [obj[0][0]]
         return obj
 

--- a/tests/cases/optional.cddl
+++ b/tests/cases/optional.cddl
@@ -1,0 +1,8 @@
+MEM_CONFIG = [
+	READ: ( 1 / 0 ),
+	? N: 0..15
+]
+
+cfg = {
+	? "mem_config" => MEM_CONFIG
+}

--- a/tests/scripts/run_tests.py
+++ b/tests/scripts/run_tests.py
@@ -20,6 +20,7 @@ p_root = Path(__file__).absolute().parents[2]
 p_tests = Path(p_root, 'tests')
 p_manifest = Path(p_tests, 'cases/manifest12.cddl')
 p_test_vectors = tuple(Path(p_tests, f'cases/manifest12_example{i}.cborhex') for i in range(6))
+p_optional = Path(p_tests, 'cases/optional.cddl')
 
 
 class Testn(TestCase):
@@ -204,6 +205,20 @@ class TestCLI(TestCase):
 
     def test_5(self):
         self.do_testn(5)
+
+
+class TestOptional(TestCase):
+    def test_0(self):
+        with open(p_optional, 'r') as f:
+            my_types = cddl_gen.DataTranslator.from_cddl(f.read(), 16)
+        cddl = my_types['cfg']
+        test_yaml = """
+            mem_config:
+                - 0
+                - 5"""
+        decoded = cddl.decode_str_yaml(test_yaml)
+        self.assertEqual(decoded.mem_config[0].READ.union_choice, "uint0")
+        self.assertEqual(decoded.mem_config[0].N, [5])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Only attempt to flatten lists or tuples.
Without this, the script fails when the inner object does not have a
length.

Fixes #66

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>