### PR TITLE
Change quantifier syntax from x**y to x*y

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ An element can be repeated:
  - `?`: 0 or 1 time. E.g. `Foo = [int, ?bstr]`, where Foo is a list with an int possibly followed by a bstr.
  - `*`: 0 or more times. E.g. `Foo = [*tstr]`, where Foo is a list containing 0 or more tstrs.
  - `+`: 1 or more times. E.g. `Foo = [+Bar]`.
- - `x**y`: Between x and y times, inclusive. E.g. `Foo = {4**8(int => bstr)}` where Foo is a map with 4 to 8 key/value pairs where each key is an int and each value is a bstr.
+ - `x*y`: Between x and y times, inclusive. E.g. `Foo = {4*8(int => bstr)}` where Foo is a map with 4 to 8 key/value pairs where each key is an int and each value is a bstr.
 
 Note that in the cddl_gen script and its generated code, the number of entries supported via `*` and `+` is affected by the default_max_qty value.
 

--- a/cddl_gen/cddl_gen.py
+++ b/cddl_gen/cddl_gen.py
@@ -429,7 +429,7 @@ class CddlParser:
             (r"\?", lambda mo: (0, 1)),
             (r"\*", lambda mo: (0, None)),
             (r"\+", lambda mo: (1, None)),
-            (r"(\d*)\*\*(\d*)", lambda mo: (int(mo.groups()[0] or 0), int(mo.groups()[1] or 0))),
+            (r"(\d*)\*\*?(\d*)", lambda mo: (int(mo.groups()[0] or 0), int(mo.groups()[1] or 0))),
         ]
 
         self.quantifier = quantifier
@@ -590,7 +590,7 @@ class CddlParser:
              lambda key_str: self.set_key_or_label(keystr)),
             (r'([+*?])',
              self.set_quantifier),
-            (r'(\d*\*\*\d*)',
+            (r'(\d*\*\*?\d*)',
              self.set_quantifier),
             (r'uint(?!\w)',
              lambda _: self.type_and_value("UINT", lambda: None)),

--- a/tests/cases/manifest2.cddl
+++ b/tests/cases/manifest2.cddl
@@ -110,7 +110,7 @@ SUIT_Component_Reference = {
 }
 
 SUIT_Command = (SUIT_Condition / SUIT_Directive / SUIT_Command_Custom)
-SUIT_Command_Sequence = [ 1**20 SUIT_Command ]
+SUIT_Command_Sequence = [ 1*20 SUIT_Command ]
 
 SUIT_Command_Custom = (nint, bstr)
 SUIT_Condition //= (suit-condition-vendor-identifier, nil)

--- a/tests/cases/manifest3.cddl
+++ b/tests/cases/manifest3.cddl
@@ -114,7 +114,7 @@ SUIT_Component_Reference = {
     suit-component-dependency-index => uint
 }
 
-SUIT_Command_Sequence = [ 1**6 (
+SUIT_Command_Sequence = [ 1*6 (
     SUIT_Condition // SUIT_Directive // SUIT_Command_Custom
 ) ]
 

--- a/tests/cases/manifest9_simple.cddl
+++ b/tests/cases/manifest9_simple.cddl
@@ -67,7 +67,7 @@ SUIT_Components           = [ + SUIT_Component_Identifier ]
 SUIT_Component_Identifier =  [* bstr]
 
 SUIT_Common_Sequence = [
-    1**10 ( SUIT_Condition // SUIT_Common_Commands )
+    1*10 ( SUIT_Condition // SUIT_Common_Commands )
 ]
 
 SUIT_Common_Commands //= (suit-directive-set-component-index,  uint/bool)
@@ -79,7 +79,7 @@ SUIT_Common_Commands //= (suit-condition-vendor-identifier, SUIT_Reporting_Polic
 SUIT_Common_Commands //= (suit-condition-class-identifier,  SUIT_Reporting_Policy)
 
 
-SUIT_Command_Sequence = [ 1**10 (
+SUIT_Command_Sequence = [ 1*10 (
     SUIT_Condition // SUIT_Directive
 ) ]
 
@@ -102,7 +102,7 @@ SUIT_Directive //= (suit-directive-fetch-uri-list,       SUIT_Reporting_Policy)
 
 SUIT_Reporting_Policy = uint
 
-SUIT_Parameters = {1**10 SUIT_Parameter}
+SUIT_Parameters = {1*10 SUIT_Parameter}
 
 SUIT_Parameter //= (suit-parameter-vendor-identifier => RFC4122_UUID)
 SUIT_Parameter //= (suit-parameter-class-identifier => RFC4122_UUID)

--- a/tests/cases/serial_recovery.cddl
+++ b/tests/cases/serial_recovery.cddl
@@ -12,5 +12,5 @@ Member = ("image" => int) /
 	(tstr => any)
 
 Upload = {
-	3**8members: Member
+	3*8members: Member
 }

--- a/tests/cases/strange.cddl
+++ b/tests/cases/strange.cddl
@@ -52,15 +52,15 @@ Union = Group / MultiGroup / (3,4) / "\"hello\""
 Map = {
 	listkey: [5,6] => bool,
 	union: (7=>uint) / (-8=>uint),
-	twotothree: 2**3 nil => bstr,
+	twotothree: 2*3 nil => bstr,
 }
 
 NestedListMap = [*{?1 => 4}]
 NestedMapListMap = {+[] => [*{}]}
 
 Level1 = [Level2]
-Level2 = [2**3Level3]
-Level3 = [4**5Level4]
+Level2 = [2**3Level3] ; Use ** here to test backwards compatibility.
+Level3 = [4*5Level4]
 Level4 = [0]
 
 Range = [


### PR DESCRIPTION
x*y is the correct syntax according to the spec.
x**y is still allowed for backwards compatibility.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>