### PR TITLE
cbor_common: Rename and add docs to improve readability

### DIFF
--- a/include/cbor_common.h
+++ b/include/cbor_common.h
@@ -118,19 +118,32 @@ do {\
 
 #define BOOL_TO_PRIM 20 ///! In CBOR, false/true have the values 20/21
 
-#define FLAG_RESTORE 1UL
-#define FLAG_DISCARD 2UL
-#define FLAG_TRANSFER_PAYLOAD 4UL
+#define FLAG_RESTORE 1UL ///! Restore from the backup.
+#define FLAG_CONSUME 2UL ///! Consume the backup.
+#define FLAG_TRANSFER_PAYLOAD 4UL ///! Keep the pre-restore payload after restoring.
 
+/** Take a backup of the current state. Overwrite the current elem_count. */
 bool new_backup(cbor_state_t *state, uint32_t new_elem_count);
 
-bool restore_backup(cbor_state_t *state, uint32_t flags,
-		uint32_t max_elem_count);
+/** Consult the most recent backup. In doing so, check whether elem_count is
+ *  within max_elem_count, and return the result.
+ *  Also, take action based on the flags (See FLAG_*).
+ */
+bool process_backup(cbor_state_t *state, uint32_t flags, uint32_t max_elem_count);
 
+/** Convenience function for starting encoding/decoding of a union.
+ *  Takes a new backup.
+ */
 bool union_start_code(cbor_state_t *state);
 
+/** Convenience function before encoding/decoding one element of a union.
+ *  Restores the backup, without consuming it.
+ */
 bool union_elem_code(cbor_state_t *state);
 
+/** Convenience function before encoding/decoding one element of a union.
+ *  Consumes the backup without restoring it.
+ */
 bool union_end_code(cbor_state_t *state);
 
 bool entry_function(const uint8_t *payload, uint32_t payload_len,

--- a/src/cbor_common.c
+++ b/src/cbor_common.c
@@ -35,7 +35,7 @@ bool new_backup(cbor_state_t *state, uint32_t new_elem_count)
 }
 
 
-bool restore_backup(cbor_state_t *state, uint32_t flags,
+bool process_backup(cbor_state_t *state, uint32_t flags,
 		uint32_t max_elem_count)
 {
 	const uint8_t *payload = state->payload;
@@ -54,7 +54,7 @@ bool restore_backup(cbor_state_t *state, uint32_t flags,
 			sizeof(cbor_state_t));
 	}
 
-	if (flags & FLAG_DISCARD) {
+	if (flags & FLAG_CONSUME) {
 		state->backups->current_backup--;
 	}
 
@@ -83,7 +83,7 @@ bool union_start_code(cbor_state_t *state)
 
 bool union_elem_code(cbor_state_t *state)
 {
-	if (!restore_backup(state, FLAG_RESTORE, state->elem_count)) {
+	if (!process_backup(state, FLAG_RESTORE, state->elem_count)) {
 		FAIL();
 	}
 	return true;
@@ -91,7 +91,7 @@ bool union_elem_code(cbor_state_t *state)
 
 bool union_end_code(cbor_state_t *state)
 {
-	if (!restore_backup(state, FLAG_DISCARD, state->elem_count)) {
+	if (!process_backup(state, FLAG_CONSUME, state->elem_count)) {
 		FAIL();
 	}
 	return true;

--- a/src/cbor_decode.c
+++ b/src/cbor_decode.c
@@ -273,8 +273,8 @@ bool bstrx_cbor_end_decode(cbor_state_t *state)
 	if (state->payload != state->payload_end) {
 		FAIL();
 	}
-	if (!restore_backup(state,
-			FLAG_RESTORE | FLAG_DISCARD | FLAG_TRANSFER_PAYLOAD,
+	if (!process_backup(state,
+			FLAG_RESTORE | FLAG_CONSUME | FLAG_TRANSFER_PAYLOAD,
 			0xFFFFFFFF)) {
 		FAIL();
 	}
@@ -378,8 +378,8 @@ bool map_start_decode(cbor_state_t *state)
 
 bool list_map_end_decode(cbor_state_t *state)
 {
-	if (!restore_backup(state,
-			FLAG_RESTORE | FLAG_DISCARD | FLAG_TRANSFER_PAYLOAD,
+	if (!process_backup(state,
+			FLAG_RESTORE | FLAG_CONSUME | FLAG_TRANSFER_PAYLOAD,
 			0)) {
 		FAIL();
 	}

--- a/src/cbor_encode.c
+++ b/src/cbor_encode.c
@@ -218,7 +218,7 @@ bool bstrx_cbor_end_encode(cbor_state_t *state)
 {
 	const uint8_t *payload = state->payload;
 
-	if (!restore_backup(state, FLAG_RESTORE | FLAG_DISCARD, 0xFFFFFFFF)) {
+	if (!process_backup(state, FLAG_RESTORE | FLAG_CONSUME, 0xFFFFFFFF)) {
 		FAIL();
 	}
 	cbor_string_type_t value;
@@ -309,7 +309,7 @@ bool list_map_end_encode(cbor_state_t *state, uint32_t max_num,
 	uint32_t max_header_len = get_result_len(&max_num, 4);
 	uint32_t header_len = get_result_len(&list_count, 4);
 
-	if (!restore_backup(state, FLAG_RESTORE | FLAG_DISCARD, 0xFFFFFFFF)) {
+	if (!process_backup(state, FLAG_RESTORE | FLAG_CONSUME, 0xFFFFFFFF)) {
 		FAIL();
 	}
 


### PR DESCRIPTION
Rename FLAG_DISCARD to FLAG_CONSUME and restore_backup to process_backup.

Add docs to the flags and functions.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>