### PR TITLE
Add support for fuzz testing with manifest12.cddl (draft-ietf-suit-manifest-12)

### DIFF
--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -10,21 +10,48 @@ project(NONE)
 
 add_subdirectory(../../ ${PROJECT_BINARY_DIR}/cddl_gen)
 
-add_executable(fuzz_pet
-    main_entry.c
-    fuzz_pet.c)
+add_executable(fuzz_target main_entry.c)
+
+target_compile_options(fuzz_target PUBLIC -Werror)
 
 file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/fuzz_input)
 
-target_cddl_source(fuzz_pet ../cases/pet.cddl ENTRY_TYPES Pet DECODE)
+set(TEST_CASE "pet"  CACHE STRING  "Test case (pet or manifest12)")
 
-execute_process(
-    COMMAND python3 ../../../cddl_gen/cddl_gen.py
-    --verbose
-    --cddl ../../cases/pet.cddl
-    convert
-    --input ../../cases/pet0.yaml
-    -t Pet
-    --output ${PROJECT_BINARY_DIR}/fuzz_input/input0.cbor
-    --output-as cbor
-    )
+if (${TEST_CASE} STREQUAL pet)
+    target_cddl_source(fuzz_target ../cases/pet.cddl ENTRY_TYPES Pet DECODE)
+
+    execute_process(
+        COMMAND python3 ../../../cddl_gen/cddl_gen.py
+        --cddl ../../cases/pet.cddl
+        convert
+        --input ../../cases/pet0.yaml
+        -t Pet
+        --output ${PROJECT_BINARY_DIR}/fuzz_input/input0.cbor
+        --output-as cbor
+        )
+
+    target_sources(fuzz_target PRIVATE fuzz_pet.c)
+
+elseif (${TEST_CASE} STREQUAL manifest12)
+    target_cddl_source(fuzz_target ../cases/manifest12.cddl DECODE
+        ENTRY_TYPES SUIT_Envelope_Tagged SUIT_Command_Sequence SUIT_Envelope)
+
+    foreach(n RANGE 0 5)
+        execute_process(
+        COMMAND python3 ../../../cddl_gen/cddl_gen.py
+        --cddl ../../cases/manifest12.cddl
+        --default-max-qty 16
+        convert
+        --input ../../cases/manifest12_example${n}.cborhex
+        -t SUIT_Envelope_Tagged
+        --output ${PROJECT_BINARY_DIR}/fuzz_input/input${n}.cbor
+        --output-as cbor
+        )
+    endforeach()
+
+    target_sources(fuzz_target PRIVATE fuzz_manifest12.c)
+
+else()
+    message(FATAL_ERROR "Invalid test case")
+endif()

--- a/tests/fuzz/fuzz_manifest12.c
+++ b/tests/fuzz/fuzz_manifest12.c
@@ -1,0 +1,136 @@
+#include "manifest12_decode.h"
+#include "main_entry.h"
+
+bool fuzz_one_input(const uint8_t *data, size_t size)
+{
+    uint32_t payload_len_out = 0;
+    struct SUIT_Envelope result;
+    struct SUIT_Envelope result2;
+    struct SUIT_Command_Sequence command_seq;
+
+    bool ret = cbor_decode_SUIT_Envelope_Tagged(data, size,
+                               &result,
+                               &payload_len_out);
+    if (!ret) {
+        return ret;
+    }
+
+    for (int i = 0; i < result._SUIT_Envelope_suit_integrated_dependency_key_count; i++) {
+        ret = cbor_decode_SUIT_Envelope(
+            result._SUIT_Envelope_suit_integrated_dependency_key[i]._SUIT_Envelope_suit_integrated_dependency_key.value,
+            result._SUIT_Envelope_suit_integrated_dependency_key[i]._SUIT_Envelope_suit_integrated_dependency_key.len,
+            &result2, &payload_len_out);
+        if (!ret) {
+            return ret;
+        }
+    }
+
+    if (result._SUIT_Envelope_suit_manifest_cbor
+              ._SUIT_Manifest__SUIT_Severable_Manifest_Members
+              ._SUIT_Severable_Manifest_Members_suit_dependency_resolution_present) {
+        ret = cbor_decode_SUIT_Command_Sequence(
+            result._SUIT_Envelope_suit_manifest_cbor
+                ._SUIT_Manifest__SUIT_Severable_Manifest_Members
+                ._SUIT_Severable_Manifest_Members_suit_dependency_resolution
+                ._SUIT_Severable_Manifest_Members_suit_dependency_resolution.value,
+            result._SUIT_Envelope_suit_manifest_cbor
+                ._SUIT_Manifest__SUIT_Severable_Manifest_Members
+                ._SUIT_Severable_Manifest_Members_suit_dependency_resolution
+                ._SUIT_Severable_Manifest_Members_suit_dependency_resolution.len,
+            &command_seq, &payload_len_out);
+        if (!ret) {
+            return ret;
+        }
+    }
+
+    if (result._SUIT_Envelope_suit_manifest_cbor
+              ._SUIT_Manifest__SUIT_Severable_Manifest_Members
+              ._SUIT_Severable_Manifest_Members_suit_payload_fetch_present) {
+        ret = cbor_decode_SUIT_Command_Sequence(
+            result._SUIT_Envelope_suit_manifest_cbor
+                ._SUIT_Manifest__SUIT_Severable_Manifest_Members
+                ._SUIT_Severable_Manifest_Members_suit_payload_fetch
+                ._SUIT_Severable_Manifest_Members_suit_payload_fetch.value,
+            result._SUIT_Envelope_suit_manifest_cbor
+                ._SUIT_Manifest__SUIT_Severable_Manifest_Members
+                ._SUIT_Severable_Manifest_Members_suit_payload_fetch
+                ._SUIT_Severable_Manifest_Members_suit_payload_fetch.len,
+            &command_seq, &payload_len_out);
+        if (!ret) {
+            return ret;
+        }
+    }
+
+    if (result._SUIT_Envelope_suit_manifest_cbor
+              ._SUIT_Manifest__SUIT_Severable_Manifest_Members
+              ._SUIT_Severable_Manifest_Members_suit_install_present) {
+        ret = cbor_decode_SUIT_Command_Sequence(
+            result._SUIT_Envelope_suit_manifest_cbor
+                ._SUIT_Manifest__SUIT_Severable_Manifest_Members
+                ._SUIT_Severable_Manifest_Members_suit_install
+                ._SUIT_Severable_Manifest_Members_suit_install.value,
+            result._SUIT_Envelope_suit_manifest_cbor
+                ._SUIT_Manifest__SUIT_Severable_Manifest_Members
+                ._SUIT_Severable_Manifest_Members_suit_install
+                ._SUIT_Severable_Manifest_Members_suit_install.len,
+            &command_seq, &payload_len_out);
+        if (!ret) {
+            return ret;
+        }
+    }
+
+    if (result._SUIT_Envelope_suit_manifest_cbor
+              ._SUIT_Manifest__SUIT_Unseverable_Members
+              ._SUIT_Unseverable_Members_suit_validate_present) {
+        ret = cbor_decode_SUIT_Command_Sequence(
+            result._SUIT_Envelope_suit_manifest_cbor
+                ._SUIT_Manifest__SUIT_Unseverable_Members
+                ._SUIT_Unseverable_Members_suit_validate
+                ._SUIT_Unseverable_Members_suit_validate.value,
+            result._SUIT_Envelope_suit_manifest_cbor
+                ._SUIT_Manifest__SUIT_Unseverable_Members
+                ._SUIT_Unseverable_Members_suit_validate
+                ._SUIT_Unseverable_Members_suit_validate.len,
+            &command_seq, &payload_len_out);
+        if (!ret) {
+            return ret;
+        }
+    }
+
+    if (result._SUIT_Envelope_suit_manifest_cbor
+              ._SUIT_Manifest__SUIT_Unseverable_Members
+              ._SUIT_Unseverable_Members_suit_load_present) {
+        ret = cbor_decode_SUIT_Command_Sequence(
+            result._SUIT_Envelope_suit_manifest_cbor
+                ._SUIT_Manifest__SUIT_Unseverable_Members
+                ._SUIT_Unseverable_Members_suit_load
+                ._SUIT_Unseverable_Members_suit_load.value,
+            result._SUIT_Envelope_suit_manifest_cbor
+                ._SUIT_Manifest__SUIT_Unseverable_Members
+                ._SUIT_Unseverable_Members_suit_load
+                ._SUIT_Unseverable_Members_suit_load.len,
+            &command_seq, &payload_len_out);
+        if (!ret) {
+            return ret;
+        }
+    }
+
+    if (result._SUIT_Envelope_suit_manifest_cbor
+              ._SUIT_Manifest__SUIT_Unseverable_Members
+              ._SUIT_Unseverable_Members_suit_run_present) {
+        ret = cbor_decode_SUIT_Command_Sequence(
+            result._SUIT_Envelope_suit_manifest_cbor
+                ._SUIT_Manifest__SUIT_Unseverable_Members
+                ._SUIT_Unseverable_Members_suit_run
+                ._SUIT_Unseverable_Members_suit_run.value,
+            result._SUIT_Envelope_suit_manifest_cbor
+                ._SUIT_Manifest__SUIT_Unseverable_Members
+                ._SUIT_Unseverable_Members_suit_run
+                ._SUIT_Unseverable_Members_suit_run.len,
+            &command_seq, &payload_len_out);
+        if (!ret) {
+            return ret;
+        }
+    }
+    return ret;
+}

--- a/tests/fuzz/test-afl.sh
+++ b/tests/fuzz/test-afl.sh
@@ -14,9 +14,10 @@ echo "Usage: $0 <seconds to run> <bit width>"
 if [ -d "build-afl" ]; then rm -r build-afl; fi
 mkdir build-afl
 pushd build-afl
-cmake .. -DCMAKE_C_COMPILER=afl-gcc -DCMAKE_C_FLAGS="-m$2"
+# cmake .. -DCMAKE_C_COMPILER=afl-gcc -DCMAKE_C_FLAGS="-m$2" -DTEST_CASE=pet
+cmake .. -DCMAKE_C_COMPILER=afl-gcc -DCMAKE_C_FLAGS="-m$2" -DTEST_CASE=manifest12
 [[ $? -ne 0 ]] && exit 1
-make fuzz_pet
+make fuzz_target
 [[ $? -ne 0 ]] && exit 1
 popd
-afl-fuzz -i build-afl/fuzz_input -o build-afl/output -V $1 -- ./build-afl/fuzz_pet
+afl-fuzz -i build-afl/fuzz_input -o build-afl/output -V $1 -- ./build-afl/fuzz_target

--- a/tests/fuzz/test-libfuzzer.sh
+++ b/tests/fuzz/test-libfuzzer.sh
@@ -7,9 +7,10 @@
 if [ -d "build-libfuzzer" ]; then rm -r build-libfuzzer; fi
 mkdir build-libfuzzer
 pushd build-libfuzzer
-cmake .. -DCMAKE_C_COMPILER=clang -DCMAKE_C_FLAGS="-fsanitize=fuzzer,address -DLIBFUZZER" -DCMAKE_C_COMPILER_WORKS=On
+cmake .. -DCMAKE_C_COMPILER=clang -DCMAKE_C_FLAGS="-fsanitize=fuzzer,address -DLIBFUZZER" -DCMAKE_C_COMPILER_WORKS=On -DTEST_CASE=manifest12
 [[ $? -ne 0 ]] && exit 1
-make fuzz_pet
+make fuzz_target
 [[ $? -ne 0 ]] && exit 1
 popd
-./build-libfuzzer/fuzz_pet -max_total_time=$1
+./build-libfuzzer/fuzz_target -max_total_time=$1
+[[ $? -ne 0 ]] && exit 1


### PR DESCRIPTION
Add some fixes needed to compile with manifest12, and fix some issues uncovered by running the manifest12 fuzz test.