### PR TITLE
cddl_gen: Fix generation of map-within-map

### DIFF
--- a/cddl_gen/cddl_gen.py
+++ b/cddl_gen/cddl_gen.py
@@ -877,9 +877,22 @@ class CddlXcoder(CddlParser):
     def choice_var_condition(self):
         return self.type == "UNION"
 
+    def reduced_key_var_condition(self):
+        if self.key is not None:
+            return True
+        return False
+
     # Whether to include a "key" variable for this element.
     def key_var_condition(self):
-        return self.key is not None
+        if self.reduced_key_var_condition():
+            return True
+        if (self.type == "OTHER"
+                # and (not self.my_types[self.value].is_unambiguous())
+                and self.my_types[self.value].key_var_condition()):
+            return True
+        if self.type in ["GROUP", "UNION"] and len(self.value) >= 1 and self.value[0].reduced_key_var_condition():
+            return True
+        return False
 
     # Whether this value adds any repeated elements by itself. I.e. excluding
     # multiple elements from children.
@@ -933,7 +946,7 @@ class CddlXcoder(CddlParser):
     def single_func_impl_condition(self):
         return (
             False
-            or self.key_var_condition()
+            or self.reduced_key_var_condition()
             or self.cbor_var_condition()
             or self.tags
             or self.type_def_condition()
@@ -1575,7 +1588,7 @@ class CodeGenerator(CddlXcoder):
             decl += self.child_declarations()
             multi_var = len(decl) > 1
 
-        if self.key_var_condition():
+        if self.reduced_key_var_condition():
             key_var = self.key.full_declaration()
             decl = key_var + decl
             multi_var = key_var != []
@@ -1632,6 +1645,7 @@ class CodeGenerator(CddlXcoder):
             multi_var = present_var != []
 
         assert multi_var == self.multi_var_condition()
+
         return decl
 
     # Return the type definition of this element. If there are multiple variables, wrap them in a struct so the function
@@ -1653,7 +1667,7 @@ class CodeGenerator(CddlXcoder):
             ret_val.extend([elem for typedef in [child.type_def() for child in self.value] for elem in typedef])
         if self.cbor_var_condition():
             ret_val.extend(self.cbor.type_def())
-        if self.key_var_condition():
+        if self.reduced_key_var_condition():
             ret_val.extend(self.key.type_def())
         if self.type == "OTHER":
             ret_val.extend(self.my_types[self.value].type_def())

--- a/tests/cases/strange.cddl
+++ b/tests/cases/strange.cddl
@@ -90,3 +90,12 @@ Unabstracted = [
 	unabstractedunion1: (choice1: 1 // choice2: 2),
 	(unabstractedunion2: 3 / choice4: 4)
 ]
+
+MyKeys = (
+	?1 => int,
+	?2 => int
+)
+
+DoubleMap = {
+	* (uint => { MyKeys })
+}

--- a/tests/cbor_decode/test1_suit_old_formats/src/main.c
+++ b/tests/cbor_decode/test1_suit_old_formats/src/main.c
@@ -298,6 +298,7 @@ zassert_equal(_SUIT_Parameters_SUIT_Parameter_URI_List,
 		      ._SUIT_Command_Sequence__SUIT_Command[1]
 		      ._SUIT_Command_union__SUIT_Directive
 		      ._SUIT_Directive_SUIT_Directive_Set_Parameters__SUIT_Parameters[0]
+		      ._SUIT_Directive_SUIT_Directive_Set_Parameters__SUIT_Parameters
 		      ._SUIT_Parameters_choice,
 		      "Expected uri list parameter");
 	zassert_equal(1,
@@ -309,6 +310,7 @@ zassert_equal(_SUIT_Parameters_SUIT_Parameter_URI_List,
 		      ._SUIT_Command_Sequence__SUIT_Command[1]
 		      ._SUIT_Command_union__SUIT_Directive
 		      ._SUIT_Directive_SUIT_Directive_Set_Parameters__SUIT_Parameters[0]
+		      ._SUIT_Directive_SUIT_Directive_Set_Parameters__SUIT_Parameters
 		      ._SUIT_Parameters_SUIT_Parameter_URI_List_cbor
 		      ._SUIT_URI_List__SUIT_Prioritized_URI_count,
 		      "Expected 1 uri");
@@ -321,6 +323,7 @@ zassert_equal(_SUIT_Parameters_SUIT_Parameter_URI_List,
 		      ._SUIT_Command_Sequence__SUIT_Command[1]
 		      ._SUIT_Command_union__SUIT_Directive
 		      ._SUIT_Directive_SUIT_Directive_Set_Parameters__SUIT_Parameters[0]
+		      ._SUIT_Directive_SUIT_Directive_Set_Parameters__SUIT_Parameters
 		      ._SUIT_Parameters_SUIT_Parameter_URI_List_cbor
 		      ._SUIT_URI_List__SUIT_Prioritized_URI[0]
 		      ._SUIT_Prioritized_URI_priority,
@@ -334,6 +337,7 @@ zassert_equal(_SUIT_Parameters_SUIT_Parameter_URI_List,
 		      ._SUIT_Command_Sequence__SUIT_Command[1]
 		      ._SUIT_Command_union__SUIT_Directive
 		      ._SUIT_Directive_SUIT_Directive_Set_Parameters__SUIT_Parameters[0]
+		      ._SUIT_Directive_SUIT_Directive_Set_Parameters__SUIT_Parameters
 		      ._SUIT_Parameters_SUIT_Parameter_URI_List_cbor
 		      ._SUIT_URI_List__SUIT_Prioritized_URI[0]
 		      ._SUIT_Prioritized_URI_uri.value,

--- a/tests/cbor_decode/test3_simple/src/main.c
+++ b/tests/cbor_decode/test3_simple/src/main.c
@@ -159,15 +159,15 @@ void test_serial1(void)
 
 	zassert_equal(5, upload._Upload_members_count,
 		"expect 5 members");
-	zassert_equal(_Member_data, upload._Upload_members[0]
+	zassert_equal(_Member_data, upload._Upload_members[0]._Upload_members
 		._Member_choice, "expect data 1st");
-	zassert_equal(_Member_image, upload._Upload_members[1]
+	zassert_equal(_Member_image, upload._Upload_members[1]._Upload_members
 		._Member_choice, "expect image 2nd");
-	zassert_equal(_Member_len, upload._Upload_members[2]
+	zassert_equal(_Member_len, upload._Upload_members[2]._Upload_members
 		._Member_choice, "expect len 3rd");
-	zassert_equal(_Member_off, upload._Upload_members[3]
+	zassert_equal(_Member_off, upload._Upload_members[3]._Upload_members
 		._Member_choice, "expect off 4th");
-	zassert_equal(_Member_sha, upload._Upload_members[4]
+	zassert_equal(_Member_sha, upload._Upload_members[4]._Upload_members
 		._Member_choice, "expect sha 5th");
 }
 
@@ -182,15 +182,15 @@ void test_serial2(void)
 
 	zassert_equal(5, upload._Upload_members_count,
 		"expect 5 members");
-	zassert_equal(_Member_data, upload._Upload_members[0]
+	zassert_equal(_Member_data, upload._Upload_members[0]._Upload_members
 		._Member_choice, "expect data 1st");
-	zassert_equal(_Member_image, upload._Upload_members[1]
+	zassert_equal(_Member_image, upload._Upload_members[1]._Upload_members
 		._Member_choice, "expect image 2nd");
-	zassert_equal(_Member_len, upload._Upload_members[2]
+	zassert_equal(_Member_len, upload._Upload_members[2]._Upload_members
 		._Member_choice, "expect len 3rd");
-	zassert_equal(_Member_off, upload._Upload_members[3]
+	zassert_equal(_Member_off, upload._Upload_members[3]._Upload_members
 		._Member_choice, "expect off 4th");
-	zassert_equal(_Member_sha, upload._Upload_members[4]
+	zassert_equal(_Member_sha, upload._Upload_members[4]._Upload_members
 		._Member_choice, "expect sha 5th");
 }
 

--- a/tests/cbor_decode/test5_strange/CMakeLists.txt
+++ b/tests/cbor_decode/test5_strange/CMakeLists.txt
@@ -32,6 +32,7 @@ target_cddl_source(app ../../cases/strange.cddl DECODE ENTRY_TYPES
   SingleInt
   SingleInt2
   Unabstracted
+  DoubleMap
   DEFAULT_MAX_QTY 6
   ${VERBOSE}
   ${CANONICAL}

--- a/tests/cbor_decode/test5_strange/src/main.c
+++ b/tests/cbor_decode/test5_strange/src/main.c
@@ -865,6 +865,31 @@ void test_unabstracted(void)
 					&result_unabstracted, &out_len), NULL);
 }
 
+void test_doublemap(void)
+{
+	uint8_t payload_doublemap0[] = {0xA2, 0x01, 0xA1, 0x01, 0x01, 0x02, 0xA1, 0x02, 0x02};
+	uint8_t payload_doublemap1_inv[] = {0xA2, 0x01, 0xA1, 0x01, 0x01, 0x02, 0xA1, 0x03, 0x02};
+	struct DoubleMap result_doublemap;
+	uint32_t out_len;
+
+	zassert_true(cbor_decode_DoubleMap(payload_doublemap0,
+					sizeof(payload_doublemap0),
+					&result_doublemap, &out_len), NULL);
+	zassert_equal(result_doublemap._DoubleMap_uintmap_count, 2, NULL);
+	zassert_equal(result_doublemap._DoubleMap_uintmap[0]._DoubleMap_uintmap_key, 1, NULL);
+	zassert_true(result_doublemap._DoubleMap_uintmap[0]._DoubleMap_uintmap__MyKeys._MyKeys_uint1int_present, NULL);
+	zassert_equal(result_doublemap._DoubleMap_uintmap[0]._DoubleMap_uintmap__MyKeys._MyKeys_uint1int._MyKeys_uint1int, 1, NULL);
+	zassert_false(result_doublemap._DoubleMap_uintmap[0]._DoubleMap_uintmap__MyKeys._MyKeys_uint2int_present, NULL);
+	zassert_equal(result_doublemap._DoubleMap_uintmap[1]._DoubleMap_uintmap_key, 2, NULL);
+	zassert_false(result_doublemap._DoubleMap_uintmap[1]._DoubleMap_uintmap__MyKeys._MyKeys_uint1int_present, NULL);
+	zassert_true(result_doublemap._DoubleMap_uintmap[1]._DoubleMap_uintmap__MyKeys._MyKeys_uint2int_present, NULL);
+	zassert_equal(result_doublemap._DoubleMap_uintmap[1]._DoubleMap_uintmap__MyKeys._MyKeys_uint2int._MyKeys_uint2int, 2, NULL);
+
+	zassert_false(cbor_decode_DoubleMap(payload_doublemap1_inv,
+					sizeof(payload_doublemap1_inv),
+					&result_doublemap, &out_len), NULL);
+}
+
 void test_main(void)
 {
 	ztest_test_suite(cbor_decode_test5,
@@ -881,7 +906,8 @@ void test_main(void)
 			 ztest_unit_test(test_range),
 			 ztest_unit_test(test_value_range),
 			 ztest_unit_test(test_single),
-			 ztest_unit_test(test_unabstracted)
+			 ztest_unit_test(test_unabstracted),
+			 ztest_unit_test(test_doublemap)
 	);
 	ztest_run_test_suite(cbor_decode_test5);
 }

--- a/tests/cbor_encode/test3_strange/CMakeLists.txt
+++ b/tests/cbor_encode/test3_strange/CMakeLists.txt
@@ -32,6 +32,7 @@ target_cddl_source(app ../../cases/strange.cddl ENCODE ENTRY_TYPES
   SingleInt
   SingleInt2
   Unabstracted
+  DoubleMap
   DEFAULT_MAX_QTY 6
   ${VERBOSE}
   ${CANONICAL}

--- a/tests/cbor_encode/test3_strange/src/main.c
+++ b/tests/cbor_encode/test3_strange/src/main.c
@@ -923,6 +923,39 @@ void test_string_overflow(void)
 	zassert_false(cbor_encode_SingleBstr(output, sizeof(output), &input_overflow0, &out_len), NULL);
 }
 
+void test_doublemap(void)
+{
+	uint8_t exp_payload_doublemap0[] = {MAP(2), 0x01, MAP(1), 0x01, 0x01, END 0x02, MAP(1), 0x02, 0x02, END END};
+	struct DoubleMap result_doublemap = {
+		._DoubleMap_uintmap_count = 2,
+		._DoubleMap_uintmap = {
+			{
+				._DoubleMap_uintmap_key = 1,
+				._DoubleMap_uintmap__MyKeys = {
+					._MyKeys_uint1int_present = true,
+					._MyKeys_uint1int = {._MyKeys_uint1int = 1},
+				}
+			},
+			{
+				._DoubleMap_uintmap_key = 2,
+				._DoubleMap_uintmap__MyKeys = {
+					._MyKeys_uint2int_present = true,
+					._MyKeys_uint2int = {._MyKeys_uint2int = 2},
+				}
+			},
+		}
+	};
+	uint8_t output[20];
+	uint32_t out_len;
+
+	zassert_true(cbor_encode_DoubleMap(output,
+					sizeof(output),
+					&result_doublemap, &out_len), NULL);
+	zassert_equal(out_len, sizeof(exp_payload_doublemap0), "%d != %d\n",
+			out_len, sizeof(exp_payload_doublemap0));
+	zassert_mem_equal(exp_payload_doublemap0, output, out_len, NULL);
+}
+
 void test_main(void)
 {
 	ztest_test_suite(cbor_encode_test3,
@@ -939,7 +972,8 @@ void test_main(void)
 			 ztest_unit_test(test_value_range),
 			 ztest_unit_test(test_single),
 			 ztest_unit_test(test_string_overflow),
-			 ztest_unit_test(test_unabstracted)
+			 ztest_unit_test(test_unabstracted),
+			 ztest_unit_test(test_doublemap)
 	);
 	ztest_run_test_suite(cbor_encode_test3);
 }


### PR DESCRIPTION
Add regression test.
Some other tests had to be adjusted because of change in generation.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>