### PR TITLE
cddl_gen.py: Add support for ranges with three dots

### DIFF
--- a/cddl_gen/cddl_gen.py
+++ b/cddl_gen/cddl_gen.py
@@ -391,7 +391,9 @@ class CddlParser:
 
     # Set the self.type and self.minValue and self.max_value (or self.min_size and self.max_size
     # depending on the type) of this element. For use during CDDL parsing.
-    def type_and_range(self, new_type, min_val, max_val):
+    def type_and_range(self, new_type, min_val, max_val, triple_dot=False):
+        if triple_dot:
+            max_val -= 1  # Triple dot means excluding the max value.
         if new_type not in ["INT", "UINT", "NINT"]:
             raise TypeError(
                 "Only integers (not %s) can have range" %
@@ -625,6 +627,15 @@ class CddlParser:
             (match_nint + r'\.\.' + match_nint,
              lambda _range: self.type_and_range(
                  "NINT", *map(lambda num: int(num, 0), _range.split("..")))),
+            (match_uint + r'\.\.\.' + match_uint,
+             lambda _range: self.type_and_range(
+                 "UINT", *map(lambda num: int(num, 0), _range.split("...")), triple_dot=True)),
+            (match_nint + r'\.\.\.' + match_uint,
+             lambda _range: self.type_and_range(
+                 "INT", *map(lambda num: int(num, 0), _range.split("...")), triple_dot=True)),
+            (match_nint + r'\.\.\.' + match_nint,
+             lambda _range: self.type_and_range(
+                 "NINT", *map(lambda num: int(num, 0), _range.split("...")), triple_dot=True)),
             (match_nint,
              lambda num: self.type_and_value("NINT", lambda: int(num, 0))),
             (match_uint,

--- a/tests/cases/strange.cddl
+++ b/tests/cases/strange.cddl
@@ -66,6 +66,7 @@ Level4 = [0]
 Range = [
 	?optMinus5to5: -5..5,
 	?optStr3to6: tstr .size 3..6,
+	?optMinus9toMinus6excl: -9...-6,
 	+multi8: 8,
 	+multiHello: "hello",
 	+multi0to10: 0..0x0A; Testing hexadecimal

--- a/tests/cbor_decode/test5_strange/src/main.c
+++ b/tests/cbor_decode/test5_strange/src/main.c
@@ -592,12 +592,27 @@ void test_range(void)
 		0x07, 0x08, 0x18 // Last too large
 	};
 
+	const uint8_t payload_range9[] = {0x84,
+		0x28,
+		0x08,
+		0x65, 0x68, 0x65, 0x6c, 0x6c, 0x6f, // "hello"
+		0x0
+	};
+
+	const uint8_t payload_range10_inv[] = {0x84,
+		0x25,
+		0x08,
+		0x65, 0x68, 0x65, 0x6c, 0x6c, 0x6f, // "hello"
+		0x0
+	};
+
 	struct Range output;
 
 	zassert_true(cbor_decode_Range(payload_range1, sizeof(payload_range1),
 				&output, NULL), NULL);
 	zassert_false(output._Range_optMinus5to5_present, NULL);
 	zassert_false(output._Range_optStr3to6_present, NULL);
+	zassert_false(output._Range_optMinus9toMinus6excl_present, NULL);
 	zassert_equal(1, output._Range_multi8_count, NULL);
 	zassert_equal(1, output._Range_multiHello_count, NULL);
 	zassert_equal(1, output._Range_multi0to10_count, NULL);
@@ -608,6 +623,7 @@ void test_range(void)
 	zassert_true(output._Range_optMinus5to5_present, NULL);
 	zassert_equal(5, output._Range_optMinus5to5, "was %d", output._Range_optMinus5to5);
 	zassert_false(output._Range_optStr3to6_present, NULL);
+	zassert_false(output._Range_optMinus9toMinus6excl_present, NULL);
 	zassert_equal(2, output._Range_multi8_count, NULL);
 	zassert_equal(1, output._Range_multiHello_count, NULL);
 	zassert_equal(2, output._Range_multi0to10_count, NULL);
@@ -626,6 +642,7 @@ void test_range(void)
 	zassert_true(output._Range_optStr3to6_present, NULL);
 	zassert_equal(5, output._Range_optStr3to6.len, NULL);
 	zassert_mem_equal("hello", output._Range_optStr3to6.value, 5, NULL);
+	zassert_false(output._Range_optMinus9toMinus6excl_present, NULL);
 	zassert_equal(1, output._Range_multi8_count, NULL);
 	zassert_equal(2, output._Range_multiHello_count, NULL);
 	zassert_equal(1, output._Range_multi0to10_count, NULL);
@@ -638,6 +655,20 @@ void test_range(void)
 				&output, NULL), NULL);
 
 	zassert_false(cbor_decode_Range(payload_range8_inv, sizeof(payload_range8_inv),
+				&output, NULL), NULL);
+
+	zassert_true(cbor_decode_Range(payload_range9, sizeof(payload_range9),
+				&output, NULL), NULL);
+	zassert_false(output._Range_optMinus5to5_present, NULL);
+	zassert_false(output._Range_optStr3to6_present, NULL);
+	zassert_true(output._Range_optMinus9toMinus6excl_present, NULL);
+	zassert_equal(-9, output._Range_optMinus9toMinus6excl, NULL);
+	zassert_equal(1, output._Range_multi8_count, NULL);
+	zassert_equal(1, output._Range_multiHello_count, NULL);
+	zassert_equal(1, output._Range_multi0to10_count, NULL);
+	zassert_equal(0, output._Range_multi0to10[0], NULL);
+
+	zassert_false(cbor_decode_Range(payload_range10_inv, sizeof(payload_range10_inv),
 				&output, NULL), NULL);
 }
 

--- a/tests/cbor_encode/test3_strange/src/main.c
+++ b/tests/cbor_encode/test3_strange/src/main.c
@@ -686,10 +686,18 @@ void test_range(void)
 		0x07,
 		END
 	};
+	const uint8_t exp_payload_range4[] = {LIST(4),
+		0x28,
+		0x08,
+		0x65, 0x68, 0x65, 0x6c, 0x6c, 0x6f, // "hello"
+		0x0,
+		END
+	};
 
 	struct Range input1 = {
 		._Range_optMinus5to5_present = false,
 		._Range_optStr3to6_present = false,
+		._Range_optMinus9toMinus6excl_present = false,
 		._Range_multi8_count = 1,
 		._Range_multiHello_count = 1,
 		._Range_multi0to10_count = 1,
@@ -699,6 +707,7 @@ void test_range(void)
 		._Range_optMinus5to5_present = true,
 		._Range_optMinus5to5 = 5,
 		._Range_optStr3to6_present = false,
+		._Range_optMinus9toMinus6excl_present = false,
 		._Range_multi8_count = 2,
 		._Range_multiHello_count = 1,
 		._Range_multi0to10_count = 2,
@@ -711,10 +720,31 @@ void test_range(void)
 			.value = "hello",
 			.len = 5,
 		},
+		._Range_optMinus9toMinus6excl_present = false,
 		._Range_multi8_count = 1,
 		._Range_multiHello_count = 2,
 		._Range_multi0to10_count = 1,
 		._Range_multi0to10 = {7},
+	};
+	struct Range input4 = {
+		._Range_optMinus5to5_present = false,
+		._Range_optStr3to6_present = false,
+		._Range_optMinus9toMinus6excl_present = true,
+		._Range_optMinus9toMinus6excl = -9,
+		._Range_multi8_count = 1,
+		._Range_multiHello_count = 1,
+		._Range_multi0to10_count = 1,
+		._Range_multi0to10 = {0},
+	};
+	struct Range input5_inv = {
+		._Range_optMinus5to5_present = false,
+		._Range_optStr3to6_present = false,
+		._Range_optMinus9toMinus6excl_present = true,
+		._Range_optMinus9toMinus6excl = -6,
+		._Range_multi8_count = 1,
+		._Range_multiHello_count = 1,
+		._Range_multi0to10_count = 1,
+		._Range_multi0to10 = {0},
 	};
 
 	uint8_t output[25];
@@ -734,6 +764,14 @@ void test_range(void)
 				&out_len), NULL);
 	zassert_equal(sizeof(exp_payload_range3), out_len, NULL);
 	zassert_mem_equal(exp_payload_range3, output, sizeof(exp_payload_range3), NULL);
+
+	zassert_true(cbor_encode_Range(output, sizeof(output), &input4,
+				&out_len), NULL);
+	zassert_equal(sizeof(exp_payload_range4), out_len, NULL);
+	zassert_mem_equal(exp_payload_range4, output, sizeof(exp_payload_range4), NULL);
+
+	zassert_false(cbor_encode_Range(output, sizeof(output), &input5_inv,
+				&out_len), NULL);
 }
 
 void test_value_range(void)


### PR DESCRIPTION
When there are three dots in the range (e.g. 1...5), the max is excluded
from the range, so that 1...5 is equivalent to 1..4

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>