### PR TITLE
cddl_gen.py: Fix bug where range checks were dropped

### DIFF
--- a/cddl_gen/cddl_gen.py
+++ b/cddl_gen/cddl_gen.py
@@ -1950,7 +1950,7 @@ class CodeGenerator(CddlXcoder):
                 for tag in self.tags]
 
     def range_checks(self, access):
-        if self.value is not None:
+        if self.type != "OTHER" and self.value is not None:
             return []
 
         # return []


### PR DESCRIPTION
They were dropped if belonging to a simple type. When an element was
OTHER, the code never reached the point where the range checks from
my_types[self.value] were added.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>