### PR TITLE
cbor_decode.c: Fix bug where a 'nil' could be interpreted as true

### DIFF
--- a/src/cbor_decode.c
+++ b/src/cbor_decode.c
@@ -448,7 +448,13 @@ bool boolx_decode(cbor_state_t *state, bool *result)
 	if (!primx_decode(state, &tmp_result)) {
 		FAIL();
 	}
-	(*result) = tmp_result - BOOL_TO_PRIM;
+
+	tmp_result -= BOOL_TO_PRIM;
+
+	if (tmp_result > 1) {
+		FAIL_RESTORE();
+	}
+	(*result) = tmp_result;
 
 	cbor_print("boolval: %u\r\n", *result);
 	return true;


### PR DESCRIPTION
'nil' is 0xF6, 'true' is 0xF5. Any value 0xF5 or above would be
interpreted as 'true' if boolx_decode or boolx_expect were called.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>