### PR TITLE
zephyr: module.yml: Change cmake-ext to True

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,6 +1,6 @@
 name: cddl-gen
 
 build:
-  cmake-ext: False
+  cmake-ext: True
   kconfig-ext: True
 


### PR DESCRIPTION
The top level CMakeLists.txt has already been removed.
Make this change so a CMakeLists.txt can be placed inside the sdk-nrf
repo.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>