### PR TITLE
run-tests.yaml: Change names of test jobs

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   merge-test:
     runs-on: ubuntu-latest
-    name: Run tests
+    name: Merge tests
 
     steps:
     - name: Checkout the code
@@ -78,7 +78,7 @@ jobs:
 
   release-test:
     runs-on: ubuntu-latest
-    name: Run tests
+    name: Release tests
     needs: merge-test
     if: "startswith(github.head_ref, 'release/')"
 


### PR DESCRIPTION
They were both called "Run tests". Change to "Merge tests"
and "Release tests".

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>